### PR TITLE
Fix MCP server metadata sync issues

### DIFF
--- a/src/design-system-data.ts
+++ b/src/design-system-data.ts
@@ -105,11 +105,6 @@ export const designSystemData: DesignSystemData = {
       title: 'Voice and Tone',
       body: 'Guidelines for consistent voice and tone across content.',
       filePath: 'content-style-guide/voice-and-tone.md'
-    },
-    'dictionary': {
-      title: 'Dictionary',
-      body: 'Terminology and language standards.',
-      filePath: 'content-style-guide/dictionary.md'
     }
   },
   accessibility: {
@@ -154,11 +149,6 @@ export const designSystemData: DesignSystemData = {
       title: 'Pane Layouts',
       body: 'Multi-pane layout patterns for complex interfaces.',
       filePath: 'layouts/pane-layouts.md'
-    },
-    'portals': {
-      title: 'Portals',
-      body: 'Portal and hub page layout patterns.',
-      filePath: 'layouts/portals.md'
     },
     'record-views': {
       title: 'Record Views',


### PR DESCRIPTION
## Problem

The MCP server metadata contained references to two files that don't exist in the design-system-docs repository:
- `content-style-guide/dictionary.md`
- `layouts/portals.md`

This caused the MCP server to be out of sync with the actual repository content.

## Solution

Removed the references to these non-existent files from the `design-system-data.ts` file.

## Testing

- [x] Verified files don't exist in design-system-docs repo
- [x] Updated metadata structure
- [x] No breaking changes to existing functionality

Fixes #55 (partial - addresses the missing file references)