### PR TITLE
Rename CLAUDE.md to AGENTS.md and clean up agent guidance

### DIFF
--- a/.kiro/specs/remote-mcp-server/design.md
+++ b/.kiro/specs/remote-mcp-server/design.md
@@ -1,0 +1,435 @@
+# Design Document
+
+## Overview
+
+This design transforms the existing local MCP server into a remote server accessible via HTTP and WebSocket connections. The solution maintains full backward compatibility while adding remote access capabilities, authentication for internal documentation, and production-ready deployment features.
+
+The architecture leverages the existing MCP SDK but replaces the stdio transport with HTTP/WebSocket transports, adds an Express.js web server layer for HTTP endpoints, and implements proper security, monitoring, and deployment configurations.
+
+## Architecture
+
+### High-Level Architecture
+
+```mermaid
+graph TB
+    subgraph "Client Applications"
+        CD[Claude Desktop]
+        AQ[Amazon Q]
+        HC[HTTP Clients]
+    end
+    
+    subgraph "Load Balancer / CDN"
+        LB[Load Balancer]
+    end
+    
+    subgraph "Remote MCP Server"
+        WS[WebSocket Handler]
+        HTTP[HTTP API Handler]
+        AUTH[Authentication Middleware]
+        RATE[Rate Limiting]
+        MCP[MCP Server Core]
+        CACHE[Response Cache]
+    end
+    
+    subgraph "External Services"
+        GH[GitHub API]
+        GHINT[GitHub Internal Repos]
+    end
+    
+    subgraph "Monitoring & Logging"
+        LOGS[Structured Logging]
+        METRICS[Metrics Collection]
+        HEALTH[Health Checks]
+    end
+    
+    CD -->|WebSocket| LB
+    AQ -->|WebSocket| LB
+    HC -->|HTTP| LB
+    
+    LB --> WS
+    LB --> HTTP
+    
+    WS --> AUTH
+    HTTP --> AUTH
+    AUTH --> RATE
+    RATE --> MCP
+    
+    MCP --> CACHE
+    MCP --> GH
+    MCP --> GHINT
+    
+    WS --> LOGS
+    HTTP --> LOGS
+    MCP --> METRICS
+    HTTP --> HEALTH
+```
+
+### Transport Layer Design
+
+The server will support multiple transport mechanisms:
+
+1. **WebSocket Transport**: Primary transport for MCP clients (Claude Desktop, Amazon Q)
+2. **HTTP REST API**: Alternative access for web applications and direct integration
+3. **Backward Compatibility**: Maintain stdio transport for local development
+
+### Deployment Architecture
+
+```mermaid
+graph TB
+    subgraph "Production Environment"
+        subgraph "Container Platform (Docker)"
+            APP[MCP Server Container]
+            ENV[Environment Config]
+        end
+        
+        subgraph "Cloud Platform Options"
+            RAILWAY[Railway]
+            RENDER[Render]
+            FLY[Fly.io]
+            HEROKU[Heroku]
+        end
+        
+        subgraph "Monitoring Stack"
+            LOGS[Centralized Logging]
+            METRICS[Application Metrics]
+            ALERTS[Error Alerting]
+        end
+    end
+    
+    APP --> LOGS
+    APP --> METRICS
+    METRICS --> ALERTS
+```
+
+## Components and Interfaces
+
+### 1. Transport Abstraction Layer
+
+**Purpose**: Provide unified interface for different transport mechanisms
+
+```typescript
+interface TransportHandler {
+  initialize(): Promise<void>;
+  handleRequest(request: MCPRequest): Promise<MCPResponse>;
+  close(): Promise<void>;
+}
+
+class WebSocketTransport implements TransportHandler {
+  // WebSocket-specific implementation
+}
+
+class HttpTransport implements TransportHandler {
+  // HTTP REST API implementation
+}
+
+class StdioTransport implements TransportHandler {
+  // Existing stdio implementation (for local dev)
+}
+```
+
+### 2. Authentication & Authorization Service
+
+**Purpose**: Handle authentication for internal documentation access
+
+```typescript
+interface AuthService {
+  validateToken(token: string): Promise<AuthResult>;
+  hasInternalAccess(authResult: AuthResult): boolean;
+  generateApiKey(): string;
+}
+
+interface AuthResult {
+  isValid: boolean;
+  userId?: string;
+  permissions: string[];
+  rateLimitTier: 'public' | 'authenticated' | 'premium';
+}
+```
+
+### 3. Rate Limiting Service
+
+**Purpose**: Prevent abuse and ensure fair usage
+
+```typescript
+interface RateLimiter {
+  checkLimit(clientId: string, tier: string): Promise<RateLimitResult>;
+  recordRequest(clientId: string): Promise<void>;
+}
+
+interface RateLimitResult {
+  allowed: boolean;
+  remainingRequests: number;
+  resetTime: Date;
+}
+```
+
+### 4. Enhanced MCP Server Core
+
+**Purpose**: Extended MCP server with remote capabilities
+
+```typescript
+class RemoteMCPServer extends McpServer {
+  private authService: AuthService;
+  private rateLimiter: RateLimiter;
+  private cache: ResponseCache;
+  private logger: Logger;
+  
+  async handleAuthenticatedRequest(
+    request: MCPRequest, 
+    auth: AuthResult
+  ): Promise<MCPResponse>;
+}
+```
+
+### 5. Configuration Management
+
+**Purpose**: Environment-based configuration for different deployment scenarios
+
+```typescript
+interface ServerConfig {
+  server: {
+    port: number;
+    host: string;
+    cors: CorsConfig;
+    ssl: SSLConfig;
+  };
+  auth: {
+    required: boolean;
+    apiKeyHeader: string;
+    internalTokenRequired: boolean;
+  };
+  rateLimit: {
+    public: RateLimitConfig;
+    authenticated: RateLimitConfig;
+  };
+  github: {
+    publicRepo: GitHubRepoConfig;
+    internalRepo?: GitHubRepoConfig;
+  };
+  monitoring: {
+    logging: LoggingConfig;
+    metrics: MetricsConfig;
+    healthCheck: HealthCheckConfig;
+  };
+}
+```
+
+## Data Models
+
+### Request/Response Models
+
+```typescript
+// Enhanced MCP Request with authentication context
+interface AuthenticatedMCPRequest extends MCPRequest {
+  auth?: AuthResult;
+  clientInfo: {
+    userAgent: string;
+    ipAddress: string;
+    clientId: string;
+  };
+}
+
+// Enhanced MCP Response with metadata
+interface EnhancedMCPResponse extends MCPResponse {
+  metadata: {
+    source: 'public' | 'internal' | 'mixed';
+    cached: boolean;
+    processingTime: number;
+    rateLimitInfo: RateLimitResult;
+  };
+}
+```
+
+### Configuration Models
+
+```typescript
+interface GitHubRepoConfig {
+  owner: string;
+  repo: string;
+  token?: string;
+  branch: string;
+  cacheTTL: number;
+}
+
+interface RateLimitConfig {
+  requestsPerMinute: number;
+  requestsPerHour: number;
+  burstLimit: number;
+}
+
+interface CorsConfig {
+  origins: string[];
+  methods: string[];
+  allowCredentials: boolean;
+}
+```
+
+## Error Handling
+
+### Error Classification
+
+1. **Client Errors (4xx)**
+   - 400: Invalid request format
+   - 401: Authentication required/failed
+   - 403: Insufficient permissions
+   - 404: Component/category not found
+   - 429: Rate limit exceeded
+
+2. **Server Errors (5xx)**
+   - 500: Internal server error
+   - 502: GitHub API unavailable
+   - 503: Service temporarily unavailable
+   - 504: Request timeout
+
+### Error Response Format
+
+```typescript
+interface ErrorResponse {
+  error: {
+    code: string;
+    message: string;
+    details?: any;
+    timestamp: string;
+    requestId: string;
+  };
+  metadata: {
+    rateLimitInfo?: RateLimitResult;
+    retryAfter?: number;
+  };
+}
+```
+
+### Graceful Degradation
+
+- **GitHub API Failures**: Return cached content with staleness indicators
+- **Internal Repo Unavailable**: Fall back to public documentation only
+- **Rate Limit Exceeded**: Provide clear retry guidance
+- **Authentication Issues**: Gracefully handle with public-only access
+
+## Testing Strategy
+
+### Unit Testing
+
+- **Transport Handlers**: Test WebSocket and HTTP request/response handling
+- **Authentication Service**: Test token validation and permission checking
+- **Rate Limiting**: Test limit enforcement and reset behavior
+- **MCP Server Core**: Test tool execution with authentication context
+
+### Integration Testing
+
+- **End-to-End Flows**: Test complete request flows from client to GitHub API
+- **Authentication Integration**: Test authenticated vs unauthenticated access
+- **Multi-Transport**: Test same functionality across WebSocket and HTTP
+- **Error Scenarios**: Test graceful handling of various failure modes
+
+### Load Testing
+
+- **Rate Limiting**: Verify rate limits work under load
+- **Concurrent Connections**: Test WebSocket connection limits
+- **GitHub API Integration**: Test behavior under GitHub API rate limits
+- **Cache Performance**: Verify caching reduces external API calls
+
+### Security Testing
+
+- **Authentication Bypass**: Attempt to access internal docs without auth
+- **Input Validation**: Test malformed requests and injection attempts
+- **Rate Limit Bypass**: Attempt to circumvent rate limiting
+- **CORS Policy**: Verify cross-origin request handling
+
+## Deployment Strategy
+
+### Container Configuration
+
+```dockerfile
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production
+COPY build/ ./build/
+EXPOSE 3000
+CMD ["node", "build/server.js"]
+```
+
+### Environment Variables
+
+```bash
+# Server Configuration
+PORT=3000
+HOST=0.0.0.0
+NODE_ENV=production
+
+# Authentication
+AUTH_REQUIRED=false
+INTERNAL_AUTH_REQUIRED=true
+API_KEY_HEADER=X-API-Key
+
+# GitHub Configuration
+GITHUB_OWNER=pglevy
+GITHUB_REPO=design-system-docs
+GITHUB_TOKEN=ghp_xxx
+GITHUB_INTERNAL_REPO=design-system-docs-internal
+GITHUB_INTERNAL_TOKEN=ghp_yyy
+
+# Rate Limiting
+PUBLIC_RATE_LIMIT_PER_MINUTE=60
+AUTH_RATE_LIMIT_PER_MINUTE=300
+
+# Monitoring
+LOG_LEVEL=info
+METRICS_ENABLED=true
+HEALTH_CHECK_PATH=/health
+```
+
+### Platform-Specific Deployment
+
+#### Railway
+- Automatic HTTPS
+- Environment variable management
+- Built-in monitoring
+- Easy GitHub integration
+
+#### Render
+- Free tier available
+- Automatic deployments
+- Built-in SSL
+- Health check support
+
+#### Fly.io
+- Global edge deployment
+- Docker-based deployment
+- Built-in load balancing
+- Regional scaling
+
+### Monitoring and Observability
+
+#### Health Checks
+```typescript
+interface HealthCheck {
+  status: 'healthy' | 'degraded' | 'unhealthy';
+  timestamp: string;
+  services: {
+    github: ServiceStatus;
+    cache: ServiceStatus;
+    database?: ServiceStatus;
+  };
+  metrics: {
+    uptime: number;
+    requestCount: number;
+    errorRate: number;
+    averageResponseTime: number;
+  };
+}
+```
+
+#### Structured Logging
+- Request/response logging with correlation IDs
+- Error logging with stack traces and context
+- Performance metrics logging
+- Security event logging (auth failures, rate limit hits)
+
+#### Metrics Collection
+- Request count and response times
+- Error rates by type
+- Rate limit hit rates
+- GitHub API usage and limits
+- WebSocket connection counts

--- a/.kiro/specs/remote-mcp-server/requirements.md
+++ b/.kiro/specs/remote-mcp-server/requirements.md
@@ -1,0 +1,78 @@
+# Requirements Document
+
+## Introduction
+
+This feature transforms the existing local MCP (Model Context Protocol) server for design system documentation into a remote server that can be accessed over HTTP/WebSocket connections. The current server runs locally via stdio transport and requires users to download, configure, and run the server on their machines. The remote server will be hosted centrally, allowing users to connect directly without local installation while maintaining all existing functionality and adding new capabilities for remote access.
+
+## Requirements
+
+### Requirement 1
+
+**User Story:** As a Claude Desktop user, I want to connect to a remote MCP server without downloading or configuring anything locally, so that I can access design system documentation immediately.
+
+#### Acceptance Criteria
+
+1. WHEN a user configures Claude Desktop with a remote server URL THEN the system SHALL establish a WebSocket connection to the remote server
+2. WHEN the connection is established THEN the system SHALL provide all existing MCP tools (list-categories, list-components, get-component-details, search-design-system)
+3. WHEN the user queries the design system THEN the system SHALL return the same data format as the local version
+4. IF the remote server is unavailable THEN the system SHALL provide clear error messages indicating connection issues
+
+### Requirement 2
+
+**User Story:** As a system administrator, I want to deploy the MCP server to a cloud platform with optional authentication and rate limiting, so that I can control access and prevent abuse while keeping public documentation accessible.
+
+#### Acceptance Criteria
+
+1. WHEN deploying the server THEN the system SHALL support environment-based configuration for different deployment environments
+2. WHEN accessing public documentation THEN the system SHALL allow unauthenticated requests for public content
+3. WHEN accessing internal documentation THEN the system SHALL require authentication using API keys or tokens
+4. WHEN rate limits are exceeded THEN the system SHALL return appropriate HTTP status codes and error messages
+5. WHEN the server starts THEN the system SHALL validate all required environment variables and configuration
+6. IF authentication is required but fails THEN the system SHALL reject the connection with a 401 Unauthorized response
+
+### Requirement 3
+
+**User Story:** As a developer, I want the remote server to maintain backward compatibility with existing local configurations, so that current users can migrate seamlessly.
+
+#### Acceptance Criteria
+
+1. WHEN existing users update their configuration THEN the system SHALL support both local and remote server configurations
+2. WHEN the remote server processes requests THEN the system SHALL return identical response formats to the local version
+3. WHEN dual-source documentation features are enabled THEN the system SHALL work with both public and internal documentation sources
+4. IF a user has existing local configuration THEN the system SHALL provide migration instructions and tools
+
+### Requirement 4
+
+**User Story:** As a platform operator, I want comprehensive monitoring and logging for the remote server, so that I can track usage, debug issues, and ensure system health.
+
+#### Acceptance Criteria
+
+1. WHEN requests are processed THEN the system SHALL log request details, response times, and error conditions
+2. WHEN system health is checked THEN the system SHALL provide health check endpoints for monitoring
+3. WHEN errors occur THEN the system SHALL log detailed error information for debugging
+4. WHEN usage metrics are needed THEN the system SHALL track and report API usage statistics
+5. IF the system experiences issues THEN the system SHALL provide structured logs for troubleshooting
+
+### Requirement 5
+
+**User Story:** As a security-conscious organization, I want the remote server to implement proper security measures including HTTPS, CORS, and input validation, so that the system is secure for production use.
+
+#### Acceptance Criteria
+
+1. WHEN the server is deployed THEN the system SHALL enforce HTTPS for all connections
+2. WHEN cross-origin requests are made THEN the system SHALL implement proper CORS policies
+3. WHEN user input is received THEN the system SHALL validate and sanitize all input parameters
+4. WHEN sensitive data is handled THEN the system SHALL not log or expose authentication tokens or private repository content
+5. IF malicious requests are detected THEN the system SHALL implement rate limiting and request filtering
+
+### Requirement 6
+
+**User Story:** As a developer integrating with the MCP server, I want comprehensive API documentation and client examples, so that I can easily integrate the remote server into different applications.
+
+#### Acceptance Criteria
+
+1. WHEN developers need integration guidance THEN the system SHALL provide OpenAPI/Swagger documentation
+2. WHEN multiple client types need support THEN the system SHALL provide examples for Claude Desktop, Amazon Q, and direct HTTP clients
+3. WHEN authentication is required THEN the system SHALL document all authentication methods and token management
+4. WHEN troubleshooting is needed THEN the system SHALL provide debugging guides and common error solutions
+5. IF new features are added THEN the system SHALL maintain up-to-date documentation with version information


### PR DESCRIPTION
This PR addresses issue pglevy/design-system-docs#99 by:

## Changes Made

### 1. File Renaming
- Renamed `CLAUDE.md` to `AGENTS.md` for generic AI assistant support

### 2. Content Cleanup
- Removed historical project information and migration planning content
- Removed confusing context about GitHub migration plans
- Focused on MCP server architecture and development guidance

### 3. Improved Structure
- Clean architecture overview for AI assistants
- Clear development commands and configuration guidance
- Better integration documentation

## What's in AGENTS.md Now

- **Architecture Overview**: Core components and patterns
- **Development Commands**: Build, test, and setup instructions
- **Configuration**: Environment variables and TypeScript setup
- **MCP Integration**: How the server works with AI assistants
- **Available Tools**: Documentation of the 4 MCP tools provided
- **Development Guidelines**: Code organization and best practices

## Benefits
- Clearer focus on the MCP server's purpose
- Removed confusing historical context
- Better guidance for AI assistants working with the server
- More maintainable documentation structure

Related to pglevy/design-system-docs#99