### PR TITLE
Add community standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,69 @@
+---
+name: Bug report
+about: Create a report to help us improve the Design System MCP Server
+title: '[BUG] '
+labels: 'bug'
+assignees: ''
+---
+
+## Bug Description
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+1. Configure MCP server with '...'
+2. Run command '....'
+3. Call tool '....'
+4. See error
+
+## Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual Behavior
+
+A clear and concise description of what actually happened.
+
+## Error Messages
+
+If applicable, include any error messages or logs:
+
+```
+Paste error messages here
+```
+
+## Environment
+
+- **MCP Client**: [e.g. Claude Desktop, Amazon Q]
+- **Node.js Version**: [e.g. 18.x, 20.x]
+- **Operating System**: [e.g. macOS, Windows, Linux]
+- **Server Version**: [e.g. commit hash or version]
+
+## Configuration
+
+Please share your relevant configuration (remove any sensitive information):
+
+```json
+{
+  "mcpServers": {
+    "design-system": {
+      // your configuration here
+    }
+  }
+}
+```
+
+## Additional Context
+
+Add any other context about the problem here, such as:
+- Related MCP tools or commands
+- Impact on workflow
+- Potential solutions you've considered
+
+## Checklist
+
+- [ ] I have searched existing issues to ensure this is not a duplicate
+- [ ] I have provided clear steps to reproduce the issue
+- [ ] I have included relevant error messages or logs
+- [ ] I have specified my environment details

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,73 @@
+---
+name: Feature request
+about: Suggest an idea for improving the Design System MCP Server
+title: '[FEATURE] '
+labels: 'enhancement'
+assignees: ''
+---
+
+## Feature Summary
+
+A clear and concise description of the feature you'd like to see added to the MCP server.
+
+## Problem Statement
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] while using the MCP server.
+
+## Proposed Solution
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+## Use Cases
+
+Describe specific scenarios where this feature would be helpful:
+
+1. **Use case 1**: [Description]
+2. **Use case 2**: [Description]
+3. **Use case 3**: [Description]
+
+## Alternatives Considered
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+## MCP Server Impact
+
+Please consider and describe:
+- [ ] **New Tools**: Would this require new MCP tools?
+- [ ] **Existing Tools**: Would this modify existing tool behavior?
+- [ ] **Configuration**: Would this require new configuration options?
+- [ ] **Performance**: Are there performance considerations?
+- [ ] **Compatibility**: Would this affect compatibility with MCP clients?
+
+## Examples or References
+
+If applicable, provide:
+- Links to similar MCP server implementations
+- Code examples showing desired behavior
+- References from other MCP servers
+- Screenshots of expected client behavior
+
+## Priority
+
+How important is this feature to you?
+- [ ] Critical - Blocking current work
+- [ ] High - Would significantly improve workflow
+- [ ] Medium - Nice to have improvement
+- [ ] Low - Minor enhancement
+
+## Additional Context
+
+Add any other context about the feature request here, such as:
+- Specific MCP clients this would benefit
+- Integration scenarios
+- Related GitHub issues
+
+## Checklist
+
+- [ ] I have searched existing issues to ensure this is not a duplicate
+- [ ] I have clearly described the problem and proposed solution
+- [ ] I have considered the impact on MCP server functionality
+- [ ] I have provided relevant examples or references where applicable

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,92 @@
+# Pull Request
+
+## Description
+
+Brief description of the changes in this PR.
+
+## Related Issue
+
+Fixes #(issue number)
+
+## Type of Change
+
+Please delete options that are not relevant:
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] MCP tool addition or modification
+- [ ] Configuration enhancement
+- [ ] Performance improvement
+
+## Changes Made
+
+Please describe the changes made in this PR:
+
+- [ ] Added new MCP tool
+- [ ] Updated existing MCP tool
+- [ ] Fixed server configuration
+- [ ] Improved error handling
+- [ ] Updated documentation
+- [ ] Fixed build or deployment issues
+- [ ] Other: [Please describe]
+
+## Testing
+
+Please describe how you tested your changes:
+
+- [ ] Tested locally with Node.js (`npm run build && npm start`)
+- [ ] Verified MCP tools work correctly with Claude Desktop
+- [ ] Tested with Amazon Q CLI
+- [ ] Validated configuration options
+- [ ] Tested error scenarios
+- [ ] Verified backward compatibility
+
+## MCP Client Testing
+
+If applicable, describe testing with MCP clients:
+
+### Claude Desktop
+- [ ] Server loads correctly
+- [ ] Tools are available and functional
+- [ ] Error handling works as expected
+- [ ] Not applicable
+
+### Amazon Q CLI
+- [ ] Server integrates correctly
+- [ ] Tools respond appropriately
+- [ ] Configuration works as expected
+- [ ] Not applicable
+
+## Configuration Changes
+
+If your changes affect configuration:
+
+- [ ] I have updated the README with new configuration options
+- [ ] I have updated the example configuration files
+- [ ] I have tested with both minimal and full configurations
+- [ ] I have verified backward compatibility
+- [ ] Not applicable - no configuration changes
+
+## Documentation
+
+- [ ] I have updated relevant documentation
+- [ ] I have added usage examples where appropriate
+- [ ] I have updated the API documentation
+- [ ] I have updated setup instructions if needed
+- [ ] Not applicable - no documentation changes needed
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my own changes
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no new warnings or errors
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published
+
+## Additional Notes
+
+Add any additional notes, concerns, or context for reviewers here.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement through GitHub issues or by contacting project maintainers directly.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,165 @@
+# Contributing to Design System MCP Server
+
+Thank you for your interest in contributing to the Design System MCP Server! This guide will help you get started with contributing to this open-source project.
+
+## Code of Conduct
+
+By participating in this project, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md). Please read it before contributing.
+
+## How to Contribute
+
+### Reporting Issues
+
+- Use our [issue templates](.github/ISSUE_TEMPLATE/) to report bugs or request features
+- Search existing issues before creating a new one
+- Provide clear, detailed descriptions with examples when possible
+
+### Suggesting Enhancements
+
+- Open an issue using the feature request template
+- Explain the use case and expected behavior
+- Consider if the enhancement fits within the design system's scope
+
+### Contributing Documentation
+
+We welcome contributions to improve our design system documentation:
+
+- **Component documentation**: Add new components or improve existing ones
+- **Pattern documentation**: Document reusable design patterns
+- **Layout guidance**: Contribute page-level layout templates
+- **Accessibility improvements**: Enhance accessibility guidelines and examples
+- **Code examples**: Add or improve implementation examples
+
+## Getting Started
+
+### For Designers
+
+1. **Edit directly in GitHub**: Use GitHub's web interface to edit markdown files
+2. **Create a branch**: Always work on a feature branch for changes
+3. **Request review**: Open a pull request when ready for feedback
+4. **Collaborate**: Use PR comments for discussion and iteration
+
+### For Developers
+
+1. **Fork the repository**: Click the "Fork" button on GitHub
+2. **Clone your fork**: `git clone https://github.com/YOUR-USERNAME/design-system-docs.git`
+3. **Create a feature branch**: `git checkout -b feature/your-feature-name`
+4. **Make changes**: Edit markdown files or add new documentation
+5. **Test locally**: Run `bundle exec jekyll serve` to preview changes
+6. **Submit PR**: Push changes and open a pull request for review
+
+## Workflow Conventions
+
+### Tracking Work
+
+- Check existing issues and projects before starting work
+- Create or assign issues to avoid overlap with other contributors
+- Use clear, descriptive commit messages
+
+### Doing Work
+
+- Favor use of the web editor for simple changes to keep things accessible
+- For larger changes, work locally and test with Jekyll
+- Paste or drag-and-drop images to leverage GitHub's `user-attachment` feature
+- Keep page hierarchy as flat as possible, but use logical structure as needed
+- For pages with an "Options" section, use the term "Variants" instead
+
+### Markdown Conventions
+
+- **Front Matter**: Delete "parent" and "related" elements if not needed for the file
+- Use double space between all elements (except lists)
+- Place images after heading and subheading and before paragraphs
+- Use empty alt text for component images: `![](image-url)`
+- Put inline functions in backticks (e.g., `a!localVariables`)
+- Use `1.` for all numbers in ordered lists (sequential numbers rendered automatically)
+- Use `<br>` to break lines within a paragraph
+- Format code samples properly before copying over
+
+### File Structure
+
+Follow our established file structure:
+
+```
+design-system-docs/
+├── components/         # Individual UI components
+├── patterns/          # Reusable design patterns
+├── layouts/           # Page-level layout templates
+├── branding/          # Brand identity elements
+├── accessibility/     # Accessibility guidelines
+└── content-style-guide/ # Content and writing guidelines
+```
+
+## Review Process
+
+### Submitting Pull Requests
+
+1. **Create a clear PR title**: Use descriptive titles that explain the change
+2. **Fill out the PR template**: Provide context and testing information
+3. **Request review**: Tag relevant reviewers or use auto-assignment
+4. **Respond to feedback**: Address comments and suggestions promptly
+5. **Keep PRs focused**: One feature or fix per PR when possible
+
+### Review Guidelines
+
+- Have at least one other person review your changes
+- Anyone with write access can merge when ready
+- Delete remote branches after merge
+
+## Local Development
+
+### Prerequisites
+
+- Ruby (version specified in `.ruby-version`)
+- Bundler gem
+- Git
+
+### Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/pglevy/design-system-docs.git
+cd design-system-docs
+
+# Install dependencies
+bundle install
+
+# Serve the site locally
+bundle exec jekyll serve
+
+# View at http://localhost:4000
+```
+
+### Testing Changes
+
+- Always test your changes locally before submitting
+- Verify that all links work correctly
+- Check that images display properly
+- Ensure responsive design works across devices
+
+## Style Guidelines
+
+### Writing Style
+
+- Use clear, concise language
+- Write in active voice when possible
+- Use consistent terminology throughout
+- Include practical examples and use cases
+
+### Documentation Structure
+
+Each documentation page should include:
+
+- Clear title and description
+- Design guidelines and principles
+- Accessibility considerations
+- Implementation examples
+- Related components or patterns
+
+## Questions?
+
+- Check our [existing documentation](README.md)
+- Search through [existing issues](https://github.com/pglevy/design-system-docs/issues)
+- Start a [discussion](https://github.com/pglevy/design-system-docs/discussions) for questions
+- Reach out to maintainers for guidance
+
+Thank you for contributing to making our design system documentation better for everyone!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,153 +13,142 @@ By participating in this project, you agree to abide by our [Code of Conduct](CO
 - Use our [issue templates](.github/ISSUE_TEMPLATE/) to report bugs or request features
 - Search existing issues before creating a new one
 - Provide clear, detailed descriptions with examples when possible
+- Include your environment details (Node.js version, MCP client, OS)
 
 ### Suggesting Enhancements
 
 - Open an issue using the feature request template
 - Explain the use case and expected behavior
-- Consider if the enhancement fits within the design system's scope
+- Consider how the enhancement would benefit MCP server functionality
+- Describe any new MCP tools or configuration options needed
 
-### Contributing Documentation
+### Contributing Code
 
-We welcome contributions to improve our design system documentation:
+We welcome contributions to improve the MCP server:
 
-- **Component documentation**: Add new components or improve existing ones
-- **Pattern documentation**: Document reusable design patterns
-- **Layout guidance**: Contribute page-level layout templates
-- **Accessibility improvements**: Enhance accessibility guidelines and examples
-- **Code examples**: Add or improve implementation examples
+- **Bug fixes**: Fix issues with existing MCP tools or server functionality
+- **New MCP tools**: Add new tools to extend server capabilities
+- **Performance improvements**: Optimize server response times or memory usage
+- **Documentation updates**: Improve setup guides, API docs, or examples
+- **Configuration enhancements**: Add new configuration options or improve existing ones
 
 ## Getting Started
 
-### For Designers
-
-1. **Edit directly in GitHub**: Use GitHub's web interface to edit markdown files
-2. **Create a branch**: Always work on a feature branch for changes
-3. **Request review**: Open a pull request when ready for feedback
-4. **Collaborate**: Use PR comments for discussion and iteration
-
-### For Developers
-
-1. **Fork the repository**: Click the "Fork" button on GitHub
-2. **Clone your fork**: `git clone https://github.com/YOUR-USERNAME/design-system-docs.git`
-3. **Create a feature branch**: `git checkout -b feature/your-feature-name`
-4. **Make changes**: Edit markdown files or add new documentation
-5. **Test locally**: Run `bundle exec jekyll serve` to preview changes
-6. **Submit PR**: Push changes and open a pull request for review
-
-## Workflow Conventions
-
-### Tracking Work
-
-- Check existing issues and projects before starting work
-- Create or assign issues to avoid overlap with other contributors
-- Use clear, descriptive commit messages
-
-### Doing Work
-
-- Favor use of the web editor for simple changes to keep things accessible
-- For larger changes, work locally and test with Jekyll
-- Paste or drag-and-drop images to leverage GitHub's `user-attachment` feature
-- Keep page hierarchy as flat as possible, but use logical structure as needed
-- For pages with an "Options" section, use the term "Variants" instead
-
-### Markdown Conventions
-
-- **Front Matter**: Delete "parent" and "related" elements if not needed for the file
-- Use double space between all elements (except lists)
-- Place images after heading and subheading and before paragraphs
-- Use empty alt text for component images: `![](image-url)`
-- Put inline functions in backticks (e.g., `a!localVariables`)
-- Use `1.` for all numbers in ordered lists (sequential numbers rendered automatically)
-- Use `<br>` to break lines within a paragraph
-- Format code samples properly before copying over
-
-### File Structure
-
-Follow our established file structure:
-
-```
-design-system-docs/
-├── components/         # Individual UI components
-├── patterns/          # Reusable design patterns
-├── layouts/           # Page-level layout templates
-├── branding/          # Brand identity elements
-├── accessibility/     # Accessibility guidelines
-└── content-style-guide/ # Content and writing guidelines
-```
-
-## Review Process
-
-### Submitting Pull Requests
-
-1. **Create a clear PR title**: Use descriptive titles that explain the change
-2. **Fill out the PR template**: Provide context and testing information
-3. **Request review**: Tag relevant reviewers or use auto-assignment
-4. **Respond to feedback**: Address comments and suggestions promptly
-5. **Keep PRs focused**: One feature or fix per PR when possible
-
-### Review Guidelines
-
-- Have at least one other person review your changes
-- Anyone with write access can merge when ready
-- Delete remote branches after merge
-
-## Local Development
-
 ### Prerequisites
 
-- Ruby (version specified in `.ruby-version`)
-- Bundler gem
+- Node.js (version 18 or higher)
+- npm or yarn
 - Git
+- An MCP client for testing (Claude Desktop, Amazon Q CLI, etc.)
 
-### Setup
+### Development Setup
 
-```bash
-# Clone the repository
-git clone https://github.com/pglevy/design-system-docs.git
-cd design-system-docs
+1. **Fork the repository**: Click the "Fork" button on GitHub
+2. **Clone your fork**: 
+   ```bash
+   git clone https://github.com/YOUR-USERNAME/design-system-server.git
+   cd design-system-server
+   ```
+3. **Install dependencies**: 
+   ```bash
+   npm install
+   ```
+4. **Build the server**: 
+   ```bash
+   npm run build
+   ```
+5. **Test locally**: 
+   ```bash
+   npm start
+   ```
 
-# Install dependencies
-bundle install
+### Testing Your Changes
 
-# Serve the site locally
-bundle exec jekyll serve
+Before submitting a pull request:
 
-# View at http://localhost:4000
+1. **Build successfully**: Ensure `npm run build` completes without errors
+2. **Test with MCP client**: Configure the server in Claude Desktop or Amazon Q CLI
+3. **Verify MCP tools**: Test that all tools work as expected
+4. **Check error handling**: Test error scenarios and edge cases
+5. **Run existing tests**: If tests exist, ensure they pass
+
+### MCP Client Testing
+
+#### Claude Desktop
+1. Update your `claude_desktop_config.json` to point to your local build
+2. Restart Claude Desktop
+3. Test MCP tools in a conversation
+4. Verify error messages are helpful
+
+#### Amazon Q CLI
+1. Configure the server in your Q CLI setup
+2. Test MCP tools through the CLI
+3. Verify integration works correctly
+
+## Development Guidelines
+
+### Code Style
+
+- Follow existing code patterns and conventions
+- Use TypeScript for type safety
+- Add comments for complex logic
+- Keep functions focused and single-purpose
+
+### MCP Tool Development
+
+When adding new MCP tools:
+
+- Follow the MCP specification
+- Provide clear tool descriptions
+- Include proper parameter validation
+- Handle errors gracefully
+- Add appropriate logging
+
+### Configuration
+
+When adding configuration options:
+
+- Update the example configuration files
+- Document new options in README
+- Ensure backward compatibility
+- Provide sensible defaults
+
+## Pull Request Process
+
+1. **Create a feature branch**: `git checkout -b feature/your-feature-name`
+2. **Make your changes**: Follow the development guidelines above
+3. **Test thoroughly**: Ensure your changes work with MCP clients
+4. **Commit with clear messages**: Use descriptive commit messages
+5. **Push to your fork**: `git push origin feature/your-feature-name`
+6. **Open a pull request**: Use the PR template and provide context
+7. **Respond to feedback**: Address review comments promptly
+
+### PR Guidelines
+
+- Keep PRs focused on a single feature or fix
+- Fill out the PR template completely
+- Include testing information
+- Update documentation if needed
+- Ensure CI checks pass
+
+## Project Structure
+
+```
+design-system-server/
+├── src/                 # TypeScript source code
+├── build/              # Compiled JavaScript output
+├── docs/               # Documentation
+├── .github/            # GitHub templates and workflows
+├── package.json        # Dependencies and scripts
+├── tsconfig.json       # TypeScript configuration
+└── README.md           # Project overview
 ```
 
-### Testing Changes
+## Questions and Support
 
-- Always test your changes locally before submitting
-- Verify that all links work correctly
-- Check that images display properly
-- Ensure responsive design works across devices
+- Check our [README](README.md) for setup instructions
+- Search through [existing issues](https://github.com/pglevy/design-system-server/issues)
+- Start a [discussion](https://github.com/pglevy/design-system-server/discussions) for questions
+- Review the [MCP specification](https://modelcontextprotocol.io/docs) for technical details
 
-## Style Guidelines
-
-### Writing Style
-
-- Use clear, concise language
-- Write in active voice when possible
-- Use consistent terminology throughout
-- Include practical examples and use cases
-
-### Documentation Structure
-
-Each documentation page should include:
-
-- Clear title and description
-- Design guidelines and principles
-- Accessibility considerations
-- Implementation examples
-- Related components or patterns
-
-## Questions?
-
-- Check our [existing documentation](README.md)
-- Search through [existing issues](https://github.com/pglevy/design-system-docs/issues)
-- Start a [discussion](https://github.com/pglevy/design-system-docs/discussions) for questions
-- Reach out to maintainers for guidance
-
-Thank you for contributing to making our design system documentation better for everyone!
+Thank you for contributing to making the Design System MCP Server better for everyone!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+The Appian Design System Documentation is owned by Appian Corporation and its licensors, © 2002-2025 Appian Corporation.
+
+Reproduction, sale, or distribution of, or creation of derivative works from, the Appian Documentation is strictly prohibited by law unless Appian consents in writing.
+
+The Appian Documentation is provided on an "AS IS" and "WITH ALL FAULTS" basis, and Appian disclaims any warranties to the Appian Documentation unless set forth in a written agreement between Appian and a customer of Appian's software.
+
+Usage of the Appian Documentation does not provide any rights to the Appian software, which must be the subject of a written license agreement with Appian.
+
+The Appian Documentation may be used only for non-commercial purposes unless licensed in writing by Appian.
+
+Access, use or review of the Appian Documentation by a competitor of Appian is prohibited.


### PR DESCRIPTION
This PR adds community standards files to the repository as requested in issue #14.

## Changes Made

### Community Standards Files (copied from design-system-docs)
- **CODE_OF_CONDUCT.md**: Standard Contributor Covenant code of conduct
- **CONTRIBUTING.md**: Contributing guidelines (updated for MCP server context)
- **LICENSE**: ~MIT license~ Custom

### GitHub Templates (customized for MCP server)
- **Bug Report Template**: Updated for MCP server-specific issues with relevant environment details
- **Feature Request Template**: Focused on MCP server functionality and tools
- **Pull Request Template**: Tailored for MCP server development workflow

## Key Customizations

All templates have been customized from the original design-system-docs versions to be relevant for the MCP server project:

- Bug reports now include MCP client information, Node.js version, and server configuration
- Feature requests focus on MCP tools, server functionality, and client compatibility
- PR template includes MCP-specific testing scenarios and configuration considerations

## Testing

- [x] All files are properly formatted
- [x] Templates include relevant sections for MCP server development
- [x] Contributing guide references correct project context

Fixes #14