### PR TITLE
Update file paths for docs/ subdirectory compatibility

### DIFF
--- a/src/design-system-data.ts
+++ b/src/design-system-data.ts
@@ -78,174 +78,174 @@ export const designSystemData: DesignSystemData = {
     'logo-and-favicon': {
       title: 'Logo and Favicon',
       body: 'Guidelines for using logos and favicons consistently across applications.',
-      filePath: 'branding/logo-and-favicon.md'
+      filePath: 'docs/branding/logo-and-favicon.md'
     },
     'colors': {
       title: 'Colors',
       body: 'Color palette and usage guidelines for the design system.',
-      filePath: 'branding/colors.md'
+      filePath: 'docs/branding/colors.md'
     },
     'icons': {
       title: 'Icons',
       body: 'Icon library and usage guidelines.',
-      filePath: 'branding/icons.md'
+      filePath: 'docs/branding/icons.md'
     },
     'typography': {
       title: 'Typography',
       body: 'Typography scale, fonts, and text styling guidelines.',
-      filePath: 'branding/typography.md'
+      filePath: 'docs/branding/typography.md'
     },
     'approach-to-ai': {
       title: 'Approach to AI',
       body: 'Guidelines for incorporating AI elements in design.',
-      filePath: 'branding/approach-to-ai.md'
+      filePath: 'docs/branding/approach-to-ai.md'
     }
   },
   'content-style-guide': {
     'voice-and-tone': {
       title: 'Voice and Tone',
       body: 'Guidelines for consistent voice and tone across content.',
-      filePath: 'content-style-guide/voice-and-tone.md'
+      filePath: 'docs/content-style-guide/voice-and-tone.md'
     }
   },
   accessibility: {
     'checklist': {
       title: 'Accessibility Checklist',
       body: 'Comprehensive checklist for ensuring accessible design and development.',
-      filePath: 'accessibility/checklist.md'
+      filePath: 'docs/accessibility/checklist.md'
     }
   },
   layouts: {
     'dashboards': {
       title: 'Dashboards',
       body: 'Layout patterns for dashboard interfaces.',
-      filePath: 'layouts/dashboards.md'
+      filePath: 'docs/layouts/dashboards.md'
     },
     'empty-states': {
       title: 'Empty States',
       body: 'Layout guidance for empty state screens.',
-      filePath: 'layouts/empty-states.md'
+      filePath: 'docs/layouts/empty-states.md'
     },
     'forms': {
       title: 'Forms',
       body: 'Form layout patterns and best practices.',
-      filePath: 'layouts/forms.md'
+      filePath: 'docs/layouts/forms.md'
     },
     'grids': {
       title: 'Grids',
       body: 'Grid system and layout structures.',
-      filePath: 'layouts/grids.md'
+      filePath: 'docs/layouts/grids.md'
     },
     'landing-pages': {
       title: 'Landing Pages',
       body: 'Layout patterns for landing and marketing pages.',
-      filePath: 'layouts/landing-pages.md'
+      filePath: 'docs/layouts/landing-pages.md'
     },
     'messaging-module': {
       title: 'Messaging Module',
       body: 'Layout for messaging and communication interfaces.',
-      filePath: 'layouts/messaging-module.md'
+      filePath: 'docs/layouts/messaging-module.md'
     },
     'pane-layouts': {
       title: 'Pane Layouts',
       body: 'Multi-pane layout patterns for complex interfaces.',
-      filePath: 'layouts/pane-layouts.md'
+      filePath: 'docs/layouts/pane-layouts.md'
     },
     'record-views': {
       title: 'Record Views',
       body: 'Layout patterns for viewing and editing records.',
-      filePath: 'layouts/record-views.md'
+      filePath: 'docs/layouts/record-views.md'
     }
   },
   patterns: {
     'banners': {
       title: 'Banners',
       body: 'Banner patterns for important announcements and alerts.',
-      filePath: 'patterns/banners.md'
+      filePath: 'docs/patterns/banners.md'
     },
     'calendar-widget': {
       title: 'Calendar Widget',
       body: 'Calendar interface patterns and interactions.',
-      filePath: 'patterns/calendar-widget.md'
+      filePath: 'docs/patterns/calendar-widget.md'
     },
     'charts': {
       title: 'Charts',
       body: 'Data visualization and chart patterns.',
-      filePath: 'patterns/charts.md'
+      filePath: 'docs/patterns/charts.md'
     },
     'comment-thread': {
       title: 'Comment Thread',
       body: 'Comment and discussion thread patterns.',
-      filePath: 'patterns/comment-thread.md'
+      filePath: 'docs/patterns/comment-thread.md'
     },
     'document-summary': {
       title: 'Document Summary',
       body: 'Document summary and preview patterns.',
-      filePath: 'patterns/document-summary.md'
+      filePath: 'docs/patterns/document-summary.md'
     },
     'document-cards': {
       title: 'Document Cards',
       body: 'Card patterns for displaying document information.',
-      filePath: 'patterns/document-cards.md'
+      filePath: 'docs/patterns/document-cards.md'
     },
     'inline-dialog': {
       title: 'Inline Dialog',
       body: 'Inline dialog and contextual popup patterns.',
-      filePath: 'patterns/inline-dialog.md'
+      filePath: 'docs/patterns/inline-dialog.md'
     },
     'key-performance-indicators': {
       title: 'Key Performance Indicators',
       body: 'KPI display and dashboard patterns.',
-      filePath: 'patterns/key-performance-indicators.md'
+      filePath: 'docs/patterns/key-performance-indicators.md'
     },
     'notifications': {
       title: 'Notifications',
       body: 'Notification patterns for system messages and alerts.',
-      filePath: 'patterns/notifications.md'
+      filePath: 'docs/patterns/notifications.md'
     },
     'pick-list': {
       title: 'Pick List',
       body: 'Selection and pick list interface patterns.',
-      filePath: 'patterns/pick-list.md'
+      filePath: 'docs/patterns/pick-list.md'
     }
   },
   components: {
     'breadcrumbs': {
       title: 'Breadcrumbs',
       body: 'Navigation breadcrumb components for showing hierarchy.',
-      filePath: 'components/breadcrumbs.md'
+      filePath: 'docs/components/breadcrumbs.md'
     },
     'cards': {
       title: 'Cards',
       body: 'Card components for displaying grouped content.',
-      filePath: 'components/cards.md'
+      filePath: 'docs/components/cards.md'
     },
     'confirmation-dialog': {
       title: 'Confirmation Dialog',
       body: 'Modal dialog components for confirmations.',
-      filePath: 'components/confirmation-dialog.md'
+      filePath: 'docs/components/confirmation-dialog.md'
     },
     'milestones': {
       title: 'Milestones',
       body: 'Milestone and progress indicator components.',
-      filePath: 'components/milestones.md'
+      filePath: 'docs/components/milestones.md'
     },
     'more-less-link': {
       title: 'More / Less Link',
       body: 'Expandable content toggle components.',
-      filePath: 'components/more-less-link.md'
+      filePath: 'docs/components/more-less-link.md'
     },
     'tabs': {
       title: 'Tabs',
       body: 'Tabbed interface components for organizing content.',
-      filePath: 'components/tabs.md'
+      filePath: 'docs/components/tabs.md'
     }
   },
   'coding-guides': {
     'sail-coding-guide': {
       title: 'SAIL Coding Guide',
       body: 'Comprehensive guide for generating valid Appian SAIL interfaces using documented components and best practices.',
-      filePath: 'SAIL_CODING_GUIDE.md'
+      filePath: 'docs/SAIL_CODING_GUIDE.md'
     }
   }
 };


### PR DESCRIPTION
## Summary

Updates all file paths in `src/design-system-data.ts` to include the `docs/` prefix to maintain compatibility with the upcoming changes in the design-system-docs repository.

## Background

PR #116 in the design-system-docs repository (https://github.com/pglevy/design-system-docs/pull/116) is moving all markdown files from the root directory to a `docs/` subdirectory to support static site generation.

## Changes

- Updated 32 file paths in `designSystemData` object to include `docs/` prefix
- All categories affected: branding, content-style-guide, accessibility, layouts, patterns, components, and coding-guides

## Example Changes

- `branding/colors.md` → `docs/branding/colors.md`
- `components/cards.md` → `docs/components/cards.md`
- `patterns/banners.md` → `docs/patterns/banners.md`

## Testing

After this change is merged and the design-system-docs PR is merged, the MCP server will continue to fetch documentation files from their new locations in the `docs/` subdirectory.