### PR TITLE
Sync MCP server metadata with design-system-docs

### DIFF
--- a/src/design-system-data.ts
+++ b/src/design-system-data.ts
@@ -144,7 +144,7 @@ export const designSystemData: DesignSystemData = {
     },
     'approach-to-ai': {
       title: 'Approach to AI',
-      body: 'The UX of AI in Appian Solutions',
+      body: 'Guidelines for incorporating AI elements in app design',
       filePath: 'docs/branding/approach-to-ai.md'
     }
   },
@@ -185,12 +185,12 @@ export const designSystemData: DesignSystemData = {
     },
     'landing-pages': {
       title: 'Landing Pages',
-      body: '**Tailor Content to Target Users**',
+      body: 'Personalized home pages to show the most important content and actions for users',
       filePath: 'docs/layouts/landing-pages.md'
     },
     'messaging-module': {
       title: 'Messaging Module',
-      body: '![](https://github.com/user-attachments/assets/c4a563e1-fb73-4ac3-8233-44b4182c5f9d)',
+      body: 'Tool used to communicate with internal users. Good for when you need to search, have multiple threads, and attach multiple attachments.',
       filePath: 'docs/layouts/messaging-module.md'
     },
     'pane-layouts': {


### PR DESCRIPTION
This PR addresses issue #32 by syncing the MCP server metadata with the current state of the design-system-docs repository.

## Changes Made

### New Components Added:
- **buttons**: A button allows users to trigger an action, such as submitting a form, opening a dialog, or navigating to another page.
- **tags**: Tags are visual indicators used to highlight notable attributes of items and draw viewer attention to important characteristics.

### New Patterns Added:
- **cards-as-choices**: Cards as choices present a set of distinct options to a user in a visually engaging, easily scannable format.

### Updated Existing Entries:
- Updated titles and descriptions for all branding, content-style-guide, accessibility, layouts, patterns, and components entries to match current documentation
- Ensured all filePath entries include the required `docs/` prefix

## Testing
- ✅ Build passes successfully
- ✅ All tests pass
- ✅ MCP server functionality verified

Closes #32